### PR TITLE
fix: accept intent data also when action is not a view

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
@@ -55,9 +55,7 @@ public class IntentModule extends NativeIntentAndroidSpec {
         String action = intent.getAction();
         Uri uri = intent.getData();
 
-        if (uri != null
-            && (Intent.ACTION_VIEW.equals(action)
-                || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action))) {
+        if (uri != null) {
           initialURL = uri.toString();
         }
       }


### PR DESCRIPTION
Propagate Intent URI also when action is not a VIEW